### PR TITLE
Fix random effect name crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,79 @@
-.DS_Store
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# CMake files
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+
+# Covers JetBrains IDEs
+.idea/
+
+# CMake (when auto built by JetBrains IDEs
+cmake-build-*/
+
+# File-based project format
+*.iws
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Netbeans
+**/nbproject/private/
+**/nbproject/Makefile-*.mk
+**/nbproject/Package-*.bash
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,6 @@ project(obs-vst)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}")
 
-find_package(Qt5Widgets REQUIRED)
-
-if(APPLE)
-	find_package(Qt5MacExtras REQUIRED)
-endif(APPLE)
-
 option(VST_USE_BUNDLED_HEADERS "Build with Bundled Headers" ON)
 
 if(VST_USE_BUNDLED_HEADERS)
@@ -69,8 +63,7 @@ add_library(obs-vst MODULE
 	${vst-HEADER})
 
 target_link_libraries(obs-vst
-	libobs
-	Qt5::Widgets)
+	libobs)
 
 if(APPLE)
 	target_link_libraries(obs-vst

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,4 +72,9 @@ if(APPLE)
 		Qt5::MacExtras)
 endif(APPLE)
 
+if (WIN32)
+	target_link_libraries(obs-vst 
+		Dwmapi)
+endif(WIN32)
+
 install_obs_plugin_with_data(obs-vst data)

--- a/EditorWidget.cpp
+++ b/EditorWidget.cpp
@@ -18,13 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "headers/EditorWidget.h"
 
-EditorWidget::EditorWidget(QWidget *parent, VSTPlugin *plugin) : QWidget(parent), plugin(plugin)
+EditorWidget::EditorWidget(VSTPlugin *plugin) : plugin(plugin)
 {
-	setWindowFlags(this->windowFlags() |= Qt::MSWindowsFixedSizeDialogHint);
-}
-
-void EditorWidget::closeEvent(QCloseEvent *event)
-{
-	plugin->closeEditor();
-	UNUSED_PARAMETER(event);
 }

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -32,6 +32,30 @@ VSTPlugin::VSTPlugin(obs_source_t *sourceContext) : sourceContext{sourceContext}
 	}
 }
 
+VSTPlugin::~VSTPlugin()
+{
+    int numChannels = VST_MAX_CHANNELS;
+
+    for (int channel = 0; channel < numChannels; channel++) {
+        if (inputs[channel]) {
+            free(inputs[channel]);
+            inputs[channel] = NULL;
+        }
+        if (outputs[channel]) {
+            free(outputs[channel]);
+            outputs[channel] = NULL;
+        }
+    }
+    if (inputs) {
+        free(inputs);
+        inputs = NULL;
+    }
+    if (outputs) {
+        free(outputs);
+        outputs = NULL;
+    }
+}
+
 void VSTPlugin::loadEffectFromPath(std::string path)
 {
 	if (this->pluginPath.compare(path) != 0) {

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -177,6 +177,14 @@ void VSTPlugin::openEditor()
 	}
 }
 
+void VSTPlugin::removeEditor() {
+	if (editorWidget->windowWorker.joinable())
+		editorWidget->windowWorker.join();
+	delete editorWidget;
+	editorWidget = nullptr;
+	blog(LOG_DEBUG, "end delete worker");
+}
+
 void VSTPlugin::closeEditor()
 {
 	if (effect) {
@@ -184,9 +192,8 @@ void VSTPlugin::closeEditor()
 	}
 
 	if (editorWidget) {
+		deleteWorker = std::thread(std::bind(&VSTPlugin::removeEditor, this));;
 		editorWidget->send_close();
-		//delete editorWidget;
-		//editorWidget = nullptr;
 	}
 }
 

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -105,7 +105,7 @@ void VSTPlugin::loadEffectFromPath(std::string path)
 		effectReady = true;
 
 		if (openInterfaceWhenActive) {
-			openEditor(obs_source_properties(sourceContext));
+			openEditor();
 		}
 	}
 }
@@ -167,14 +167,13 @@ bool VSTPlugin::isEditorOpen()
 	return !!editorWidget;
 }
 
-void VSTPlugin::openEditor(obs_properties_t *props)
+void VSTPlugin::openEditor()
 {
 	if (effect && !editorWidget) {
 		editorWidget = new EditorWidget(this);
 		editorWidget->buildEffectContainer(effect);
 		editorWidget->send_setWindowTitle(effectName);
 		editorWidget->send_show();
-		sp = props;
 	}
 }
 
@@ -192,18 +191,6 @@ void VSTPlugin::closeEditor()
 	}
 
 	if (editorWidget) {
-		obs_properties_t *props = obs_properties_create();
-		obs_property_t *  list  = obs_properties_add_list(props,
-                                                               "plugin_path",
-                                                               obs_module_text("VstPlugin"),
-                                                               OBS_COMBO_TYPE_LIST,
-                                                               OBS_COMBO_FORMAT_STRING);
-
-		if (props) {
-			obs_property_set_visible(obs_properties_get(props, "open_vst_settings"), true);
-			obs_property_set_visible(obs_properties_get(props, "close_vst_settings"), false);
-		}
-
 		editorWidget->send_close();
 		deleteWorker = new std::thread(std::bind(&VSTPlugin::removeEditor, this));
 	}

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -26,6 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 VSTPlugin::VSTPlugin(obs_source_t *sourceContext) : sourceContext{sourceContext}
 {
+	memset(effectName, 0, sizeof(char) * EffectNameLength);
 
 	int numChannels = VST_MAX_CHANNELS;
 	int blocksize   = BLOCK_SIZE;
@@ -93,6 +94,10 @@ void VSTPlugin::loadEffectFromPath(std::string path)
 		effect->dispatcher(effect, effGetVendorString, 0, 0, vendorString, 0);
 
 		effect->dispatcher(effect, effOpen, 0, 0, nullptr, 0.0f);
+
+		// Fix sometimes receiving an invalid name from the plugin, makes sure
+		// there is a terminator character
+		effectName[EffectNameLength - 1] = 0;
 
 		// Set some default properties
 		size_t sampleRate = audio_output_get_sample_rate(obs_get_audio());

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -178,8 +178,10 @@ void VSTPlugin::openEditor()
 }
 
 void VSTPlugin::removeEditor() {
+	blog(LOG_DEBUG, "waiting");
 	if (editorWidget->windowWorker.joinable())
 		editorWidget->windowWorker.join();
+	blog(LOG_DEBUG, "finish waiting");
 	delete editorWidget;
 	editorWidget = nullptr;
 	blog(LOG_DEBUG, "end delete worker");
@@ -192,8 +194,10 @@ void VSTPlugin::closeEditor()
 	}
 
 	if (editorWidget) {
-		deleteWorker = std::thread(std::bind(&VSTPlugin::removeEditor, this));;
+		blog(LOG_DEBUG, "send close");
 		editorWidget->send_close();
+		blog(LOG_DEBUG, "sent");
+		deleteWorker = new std::thread(std::bind(&VSTPlugin::removeEditor, this));;
 	}
 }
 

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -65,7 +65,7 @@ VSTPlugin::~VSTPlugin()
 void VSTPlugin::loadEffectFromPath(std::string path)
 {
 	if (this->pluginPath.compare(path) != 0) {
-		closeEditor();
+		closeEditor(NULL);
 		unloadEffect();
 	}
 
@@ -184,7 +184,7 @@ void VSTPlugin::removeEditor() {
 	editorWidget = nullptr;
 }
 
-void VSTPlugin::closeEditor()
+void VSTPlugin::closeEditor(obs_properties_t *props)
 {
 	if (effect) {
 		effect->dispatcher(effect, effEditClose, 0, 0, nullptr, 0);
@@ -193,6 +193,11 @@ void VSTPlugin::closeEditor()
 	if (editorWidget) {
 		editorWidget->send_close();
 		deleteWorker = new std::thread(std::bind(&VSTPlugin::removeEditor, this));;
+
+		if (props) {
+			obs_property_set_visible(obs_properties_get(props, "open_vst_settings"), true);
+			obs_property_set_visible(obs_properties_get(props, "close_vst_settings"), false);
+		}
 	}
 }
 

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -156,11 +156,13 @@ void VSTPlugin::waitDeleteWorker()
 
 		delete deleteWorker;
 		deleteWorker = nullptr;
-    }
+	}
 }
 
 void VSTPlugin::unloadEffect()
 {
+	waitDeleteWorker();
+
 	effectReady = false;
 
 	if (effect) {
@@ -169,8 +171,6 @@ void VSTPlugin::unloadEffect()
 	}
 
 	effect = nullptr;
-
-    waitDeleteWorker();
 
 	unloadLibrary();
 }
@@ -200,6 +200,9 @@ void VSTPlugin::removeEditor() {
 
 void VSTPlugin::closeEditor()
 {
+	// Wait the last instance of the delete worker, if any
+	waitDeleteWorker();
+
 	if (effect) {
 		effect->dispatcher(effect, effEditClose, 0, 0, nullptr, 0);
 	}
@@ -207,9 +210,6 @@ void VSTPlugin::closeEditor()
 	if (editorWidget) {
 		editorWidget->send_dispatcherClose();
 		editorWidget->send_close();
-
-        // Wait the last instance of the delete worker, if any
-		waitDeleteWorker();
 
 		deleteWorker = new std::thread(std::bind(&VSTPlugin::removeEditor, this));
 	}

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -209,7 +209,7 @@ void VSTPlugin::closeEditor()
 
 	if (editorWidget) {
 		editorWidget->send_close();
-		editorWidget->send_dispatcherClose();
+		// editorWidget->send_dispatcherClose();
 
 		deleteWorker = new std::thread(std::bind(&VSTPlugin::removeEditor, this));
 	}

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -178,13 +178,10 @@ void VSTPlugin::openEditor()
 }
 
 void VSTPlugin::removeEditor() {
-	blog(LOG_DEBUG, "waiting");
 	if (editorWidget->windowWorker.joinable())
 		editorWidget->windowWorker.join();
-	blog(LOG_DEBUG, "finish waiting");
 	delete editorWidget;
 	editorWidget = nullptr;
-	blog(LOG_DEBUG, "end delete worker");
 }
 
 void VSTPlugin::closeEditor()
@@ -194,9 +191,7 @@ void VSTPlugin::closeEditor()
 	}
 
 	if (editorWidget) {
-		blog(LOG_DEBUG, "send close");
 		editorWidget->send_close();
-		blog(LOG_DEBUG, "sent");
 		deleteWorker = new std::thread(std::bind(&VSTPlugin::removeEditor, this));;
 	}
 }

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -204,12 +204,12 @@ void VSTPlugin::closeEditor()
 	waitDeleteWorker();
 
 	if (effect) {
-		effect->dispatcher(effect, effEditClose, 0, 0, nullptr, 0);
+		// effect->dispatcher(effect, effEditClose, 0, 0, nullptr, 0);
 	}
 
 	if (editorWidget) {
-		editorWidget->send_dispatcherClose();
 		editorWidget->send_close();
+		editorWidget->send_dispatcherClose();
 
 		deleteWorker = new std::thread(std::bind(&VSTPlugin::removeEditor, this));
 	}

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -185,14 +185,8 @@ void VSTPlugin::closeEditor()
 
 	if (editorWidget) {
 		editorWidget->send_close();
-
-		editorWidget->send_shutdown();
-
-		if (editorWidget->windowWorker.joinable())
-			editorWidget->windowWorker.join();
-
-		delete editorWidget;
-		editorWidget = nullptr;
+		//delete editorWidget;
+		//editorWidget = nullptr;
 	}
 }
 

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -180,6 +180,7 @@ void VSTPlugin::openEditor()
 void VSTPlugin::removeEditor() {
 	if (editorWidget->windowWorker.joinable())
 		editorWidget->windowWorker.join();
+
 	delete editorWidget;
 	editorWidget = nullptr;
 }
@@ -191,6 +192,7 @@ void VSTPlugin::closeEditor()
 	}
 
 	if (editorWidget) {
+		editorWidget->send_dispatcherClose();
 		editorWidget->send_close();
 		deleteWorker = new std::thread(std::bind(&VSTPlugin::removeEditor, this));
 	}

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -26,7 +26,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 VSTPlugin::VSTPlugin(obs_source_t *sourceContext) : sourceContext{sourceContext}
 {
-	memset(effectName, 0, sizeof(char) * EffectNameLength);
 
 	int numChannels = VST_MAX_CHANNELS;
 	int blocksize   = BLOCK_SIZE;
@@ -94,10 +93,6 @@ void VSTPlugin::loadEffectFromPath(std::string path)
 		effect->dispatcher(effect, effGetVendorString, 0, 0, vendorString, 0);
 
 		effect->dispatcher(effect, effOpen, 0, 0, nullptr, 0.0f);
-
-		// Fix sometimes receiving an invalid name from the plugin, makes sure
-		// there is a terminator character
-		effectName[EffectNameLength - 1] = 0;
 
 		// Set some default properties
 		size_t sampleRate = audio_output_get_sample_rate(obs_get_audio());

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -203,14 +203,8 @@ void VSTPlugin::closeEditor()
 	// Wait the last instance of the delete worker, if any
 	waitDeleteWorker();
 
-	if (effect) {
-		// effect->dispatcher(effect, effEditClose, 0, 0, nullptr, 0);
-	}
-
 	if (editorWidget) {
 		editorWidget->send_close();
-		// editorWidget->send_dispatcherClose();
-
 		deleteWorker = new std::thread(std::bind(&VSTPlugin::removeEditor, this));
 	}
 }

--- a/cbase64.h
+++ b/cbase64.h
@@ -1,0 +1,243 @@
+/* cbase64 - public domain base64 encoder/decoder
+
+    Do this:
+        #define CBASE64_IMPLEMENTATION
+    before you include this file in *one* C or C++ file to create the implementation.
+
+    // i.e. it should look like this:
+   #include ...
+   #include ...
+   #include ...
+   #define CBASE64_IMPLEMENTATION
+   #include "cbase64.h"
+
+*/
+
+#ifndef CBASE64_H
+#define CBASE64_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum
+{
+    step_A, step_B, step_C, step_D
+} cbase64_step;
+
+typedef struct
+{
+    cbase64_step step;
+    unsigned char result;
+} cbase64_encodestate;
+
+typedef struct
+{
+    cbase64_step step;
+    char result;
+} cbase64_decodestate;
+
+void cbase64_init_encodestate(cbase64_encodestate* state_in);
+void cbase64_init_decodestate(cbase64_decodestate* state_in);
+
+unsigned int cbase64_calc_encoded_length(unsigned int length_in);
+unsigned int cbase64_calc_decoded_length(const char* code_in, unsigned int length_in);
+
+unsigned int cbase64_encode_block(const unsigned char* data_in, unsigned int length_in,
+                                  char* code_out, cbase64_encodestate* state_in);
+
+unsigned int cbase64_decode_block(const char* code_in, unsigned int length_in,
+                                  unsigned char* data_out, cbase64_decodestate* state_in);
+
+unsigned int cbase64_encode_blockend(char* code_out, cbase64_encodestate* state_in);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CBASE64_H
+
+#ifdef CBASE64_IMPLEMENTATION
+
+char cbase64__encode_value(unsigned char value_in)
+{
+    static const char* encoding = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    return encoding[(int)value_in];
+}
+
+char cbase64__decode_value(char value_in)
+{
+    static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
+    static const char decoding_size = sizeof(decoding);
+    value_in -= 43;
+    if (value_in < 0 || value_in >= decoding_size) return -1;
+    return decoding[(int)value_in];
+}
+
+void cbase64_init_encodestate(cbase64_encodestate* state_in)
+{
+    state_in->step = step_A;
+    state_in->result = '\0';
+}
+
+void cbase64_init_decodestate(cbase64_decodestate* state_in)
+{
+    state_in->step = step_A;
+    state_in->result = '\0';
+}
+
+unsigned int cbase64_calc_encoded_length(unsigned int length_in)
+{
+    return 4 * (length_in / 3) + ((length_in % 3 != 0) ? 4 : 0);
+}
+
+unsigned int cbase64_calc_decoded_length(const char* code_in, unsigned int length_in)
+{
+    if (length_in == 0 || ((length_in & 3) != 0))
+    {
+        return 0;
+    }
+    const char secondlast = code_in[length_in - 2];
+    const char last = code_in[length_in - 1];
+    return 3 * (length_in / 4) - (secondlast == '=') - (last == '=');
+}
+
+unsigned int cbase64_encode_block(const unsigned char* data_in, unsigned int length_in,
+                                  char* code_out, cbase64_encodestate* state_in)
+{
+    const unsigned char* datachar = data_in;
+    const unsigned char* const datatextend = data_in + length_in;
+    char* codechar = code_out;
+    unsigned char result = state_in->result;
+    unsigned char fragment;
+
+    switch (state_in->step)
+    {
+        for (;;)
+        {
+    case step_A:
+            if (datachar == datatextend)
+            {
+                state_in->step = step_A;
+                state_in->result = result;
+                return codechar - code_out;
+            }
+            fragment = *datachar++;
+            result = (fragment & 0x0fc) >> 2;
+            *codechar++ = cbase64__encode_value(result);
+            result = (fragment & 0x003) << 4;
+    case step_B:
+            if (datachar == datatextend)
+            {
+                state_in->step = step_B;
+                state_in->result = result;
+                return codechar - code_out;
+            }
+            fragment = *datachar++;
+            result |= (fragment & 0x0f0) >> 4;
+            *codechar++ = cbase64__encode_value(result);
+            result = (fragment & 0x00f) << 2;
+    case step_C:
+            if (datachar == datatextend)
+            {
+                state_in->step = step_C;
+                state_in->result = result;
+                return codechar - code_out;
+            }
+            fragment = *datachar++;
+            result |= (fragment & 0x0c0) >> 6;
+            *codechar++ = cbase64__encode_value(result);
+            result  = (fragment & 0x03f) >> 0;
+            *codechar++ = cbase64__encode_value(result);
+        }
+    }
+    // control should not reach here
+    return codechar - code_out;
+}
+
+unsigned int cbase64_decode_block(const char* code_in, unsigned int length_in,
+                                  unsigned char* data_out, cbase64_decodestate* state_in)
+{
+    const char* codechar = code_in;
+    const char* const codeend = code_in + length_in;
+    unsigned char* datachar = data_out;
+    char fragment;
+    char overwrite = state_in->result;
+    
+    switch (state_in->step)
+    {
+        for (;;)
+        {
+    case step_A:
+            do {
+                if (codechar == codeend)
+                {
+                    state_in->step = step_A;
+                    state_in->result = overwrite;
+                    return datachar - data_out;
+                }
+                fragment = cbase64__decode_value(*codechar++);
+            } while (fragment < 0);
+            *datachar = (fragment & 0x03f) << 2;
+    case step_B:
+            do {
+                if (codechar == codeend)
+                {
+                    state_in->step = step_B;
+                    state_in->result = overwrite;
+                    return datachar - data_out;
+                }
+                fragment = cbase64__decode_value(*codechar++);
+            } while (fragment < 0);
+            *datachar++ |= (fragment & 0x030) >> 4;
+            overwrite    = (fragment & 0x00f) << 4;
+    case step_C:
+            do {
+                if (codechar == codeend)
+                {
+                    state_in->step = step_C;
+                    state_in->result = overwrite;
+                    return datachar - data_out;
+                }
+                fragment = cbase64__decode_value(*codechar++);
+            } while (fragment < 0);
+            *datachar++ = overwrite | (fragment & 0x03c) >> 2;
+            overwrite   = (fragment & 0x003) << 6;
+    case step_D:
+            do {
+                if (codechar == codeend)
+                {
+                    state_in->step = step_D;
+                    state_in->result = overwrite;
+                    return datachar - data_out;
+                }
+                fragment = cbase64__decode_value(*codechar++);
+            } while (fragment < 0);
+            *datachar++ = overwrite | (fragment & 0x03f);
+        }
+    }
+    // control should not reach here
+    return datachar - data_out;
+}
+
+unsigned int cbase64_encode_blockend(char* code_out, cbase64_encodestate* state_in)
+{
+    char* codechar = code_out;
+    switch (state_in->step)
+    {
+    case step_B:
+        *codechar++ = cbase64__encode_value(state_in->result);
+        *codechar++ = '=';
+        *codechar++ = '=';
+        break;
+    case step_C:
+        *codechar++ = cbase64__encode_value(state_in->result);
+        *codechar++ = '=';
+        break;
+    case step_A:
+        break;
+    }
+    return codechar - code_out;
+}
+
+#endif // CBASE64_IMPLEMENTATION

--- a/data/locale/de-DE.ini
+++ b/data/locale/de-DE.ini
@@ -1,4 +1,4 @@
 OpenPluginInterface="Öffne Plug-in-Schnittstelle"
 ClosePluginInterface="Schließe Plug-in-Schnittstelle"
-VstPlugin="VST 2.x Plug-in"
+VstPlugin="VST 2.x Plugin"
 OpenInterfaceWhenActive="Öffne Schnittstelle, wenn aktiv"

--- a/data/locale/fil-PH.ini
+++ b/data/locale/fil-PH.ini
@@ -1,0 +1,4 @@
+OpenPluginInterface="Buksan ang interface at isaksak"
+ClosePluginInterface="Isarado ang interface at isaksak"
+VstPlugin="VST 2. x Isaksak"
+OpenInterfaceWhenActive="Buksan ang interface kapag aktibo"

--- a/data/locale/fr-FR.ini
+++ b/data/locale/fr-FR.ini
@@ -1,4 +1,4 @@
 OpenPluginInterface="Afficher l'interface graphique du plug-in"
 ClosePluginInterface="Fermer l'interface graphique du plug-in"
 VstPlugin="Plug-in VST 2.x"
-OpenInterfaceWhenActive="Ouvrir l'interface lorsqu'elle est active"
+OpenInterfaceWhenActive="Ouvrir l'interface graphique du plug-in quand il est actif"

--- a/data/locale/ka-GE.ini
+++ b/data/locale/ka-GE.ini
@@ -1,0 +1,4 @@
+OpenPluginInterface="მოდულის სამართავის გახსნა"
+ClosePluginInterface="მოდულის სამართავის დახურვა"
+VstPlugin="VST 2.x მოდული"
+OpenInterfaceWhenActive="სამართავის გახსნა ამოქმედებისას"

--- a/data/locale/sr-CS.ini
+++ b/data/locale/sr-CS.ini
@@ -1,0 +1,4 @@
+OpenPluginInterface="Prikaži interfejs za priključak"
+ClosePluginInterface="Zatvori interfejs za priključak"
+VstPlugin="VST 2.x priključak"
+OpenInterfaceWhenActive="Prikaži interfejs kada je priključak aktivan"

--- a/data/locale/sr-SP.ini
+++ b/data/locale/sr-SP.ini
@@ -1,0 +1,4 @@
+OpenPluginInterface="Прикажи интерфејс за прикључак"
+ClosePluginInterface="Затвори интерфејс за прикључак"
+VstPlugin="VST 2.x прикључак"
+OpenInterfaceWhenActive="Прикажи интерфејс када је прикључак активан"

--- a/data/locale/tl-PH.ini
+++ b/data/locale/tl-PH.ini
@@ -1,0 +1,4 @@
+OpenPluginInterface="I-open ang Plug-in na Interface"
+ClosePluginInterface="I-close ang Plug-in na Interface"
+VstPlugin="VST 2.x na Plug-in"
+OpenInterfaceWhenActive="I-open ang interface kung itoy aktibo"

--- a/headers/EditorWidget.h
+++ b/headers/EditorWidget.h
@@ -51,7 +51,7 @@ class EditorWidget : public QWidget {
 #ifdef __APPLE__
 	QMacCocoaViewContainer *cocoaViewContainer = NULL;
 #elif WIN32
-
+	HWND windowHandle = NULL;
 #elif __linux__
 
 #endif

--- a/headers/EditorWidget.h
+++ b/headers/EditorWidget.h
@@ -40,6 +40,7 @@ struct sync_data {
 enum WM_USER_MSG {
 	WM_USER_SET_TITLE = WM_USER + 0,
 	WM_USER_SHOW,
+	WM_USER_CLOSE_DISPATCHER,
 	WM_USER_CLOSE
 };
 
@@ -67,13 +68,12 @@ class EditorWidget {
 
 public:
 	std::thread             windowWorker;
-	std::mutex              mtx;
-	std::condition_variable cv;
 
 	EditorWidget(VSTPlugin *plugin);
 	virtual ~EditorWidget();
 	void setWindowTitle(const char *title);
 	void show();
+	void dispatcherClose();
 	void close();
 	void buildEffectContainer(AEffect *effect);
 
@@ -81,6 +81,7 @@ public:
 
 	void send_setWindowTitle(const char *title);
 	void send_show();
+	void send_dispatcherClose();
 	void send_close();
 };
 

--- a/headers/EditorWidget.h
+++ b/headers/EditorWidget.h
@@ -27,6 +27,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "aeffectx.h"
 #include "VSTPlugin.h"
+#include <thread>
+
+enum WM_USER_MSG {
+	WM_USER_SET_TITLE = WM_USER + 0,
+};
 
 class VSTPlugin;
 
@@ -42,7 +47,8 @@ public:
 class EditorWidget {
 
 	VSTPlugin *plugin;
-
+	std::thread windowWorker;
+	AEffect *   m_effect;
 #ifdef __APPLE__
 #elif WIN32
 	HWND m_hwnd;
@@ -57,6 +63,10 @@ public:
 	void close();
 	void buildEffectContainer(AEffect *effect);
 	void handleResizeRequest(int width, int height);
+
+	void buildEffectContainer_worker();
+
+	void send_setWindowTitle(const char *title);
 };
 
 #endif // OBS_STUDIO_EDITORDIALOG_H

--- a/headers/EditorWidget.h
+++ b/headers/EditorWidget.h
@@ -39,7 +39,7 @@ public:
 	short right;
 };
 
-class EditorWidget{
+class EditorWidget {
 
 	VSTPlugin *plugin;
 

--- a/headers/EditorWidget.h
+++ b/headers/EditorWidget.h
@@ -31,6 +31,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 enum WM_USER_MSG {
 	WM_USER_SET_TITLE = WM_USER + 0,
+	WM_USER_SHOW,
+	WM_USER_CLOSE,
+	WM_USER_SHUTDOWN
 };
 
 class VSTPlugin;
@@ -47,7 +50,6 @@ public:
 class EditorWidget {
 
 	VSTPlugin *plugin;
-	std::thread windowWorker;
 	AEffect *   m_effect;
 #ifdef __APPLE__
 #elif WIN32
@@ -57,16 +59,20 @@ class EditorWidget {
 #endif
 
 public:
+	std::thread windowWorker;
+
 	EditorWidget(VSTPlugin *plugin);
 	void setWindowTitle(const char *title);
 	void show();
 	void close();
 	void buildEffectContainer(AEffect *effect);
-	void handleResizeRequest(int width, int height);
 
 	void buildEffectContainer_worker();
 
 	void send_setWindowTitle(const char *title);
+	void send_show();
+	void send_close();
+	void send_shutdown();
 };
 
 #endif // OBS_STUDIO_EDITORDIALOG_H

--- a/headers/EditorWidget.h
+++ b/headers/EditorWidget.h
@@ -66,7 +66,7 @@ class EditorWidget {
 #endif
 
 public:
-	std::thread             windowWorker;
+	std::thread windowWorker;
 
 	EditorWidget(VSTPlugin *plugin);
 	virtual ~EditorWidget();

--- a/headers/EditorWidget.h
+++ b/headers/EditorWidget.h
@@ -19,14 +19,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef OBS_STUDIO_EDITORDIALOG_H
 #define OBS_STUDIO_EDITORDIALOG_H
 
-#include <QWidget>
-#ifdef __APPLE__
-#include <QMacCocoaViewContainer>
-#elif WIN32
-#include <QWindow>
+#if WIN32
 #include <Windows.h>
 #elif __linux__
-#include <QWindow>
 #include <xcb/xcb.h>
 #endif
 
@@ -44,22 +39,23 @@ public:
 	short right;
 };
 
-class EditorWidget : public QWidget {
+class EditorWidget{
 
 	VSTPlugin *plugin;
 
 #ifdef __APPLE__
-	QMacCocoaViewContainer *cocoaViewContainer = NULL;
 #elif WIN32
-	HWND windowHandle = NULL;
+	HWND m_hwnd;
 #elif __linux__
-
+	xcb_window_t m_wid;
 #endif
 
 public:
-	EditorWidget(QWidget *parent, VSTPlugin *plugin);
+	EditorWidget(VSTPlugin *plugin);
+	void setWindowTitle(const char *title);
+	void show();
+	void close();
 	void buildEffectContainer(AEffect *effect);
-	void closeEvent(QCloseEvent *event) override;
 	void handleResizeRequest(int width, int height);
 };
 

--- a/headers/EditorWidget.h
+++ b/headers/EditorWidget.h
@@ -28,12 +28,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "aeffectx.h"
 #include "VSTPlugin.h"
 #include <thread>
+#include <mutex>
+#include <condition_variable>
+
+struct sync_data {
+	std::mutex              mtx;
+	std::condition_variable cv;
+	bool                    ran = false;
+};
 
 enum WM_USER_MSG {
 	WM_USER_SET_TITLE = WM_USER + 0,
 	WM_USER_SHOW,
-	WM_USER_CLOSE,
-	WM_USER_SHUTDOWN
+	WM_USER_CLOSE
 };
 
 class VSTPlugin;
@@ -59,9 +66,12 @@ class EditorWidget {
 #endif
 
 public:
-	std::thread windowWorker;
+	std::thread             windowWorker;
+	std::mutex              mtx;
+	std::condition_variable cv;
 
 	EditorWidget(VSTPlugin *plugin);
+	virtual ~EditorWidget();
 	void setWindowTitle(const char *title);
 	void show();
 	void close();
@@ -72,7 +82,6 @@ public:
 	void send_setWindowTitle(const char *title);
 	void send_show();
 	void send_close();
-	void send_shutdown();
 };
 
 #endif // OBS_STUDIO_EDITORDIALOG_H

--- a/headers/EditorWidget.h
+++ b/headers/EditorWidget.h
@@ -38,7 +38,9 @@ struct sync_data {
 };
 
 enum WM_USER_MSG {
-	WM_USER_SET_TITLE = WM_USER + 0,
+	// Start at index user + 5 because some plugins were causing issues when sending invalid
+	// messages to the main window
+	WM_USER_SET_TITLE = WM_USER + 5,
 	WM_USER_SHOW,
 	WM_USER_CLOSE
 };

--- a/headers/EditorWidget.h
+++ b/headers/EditorWidget.h
@@ -40,7 +40,6 @@ struct sync_data {
 enum WM_USER_MSG {
 	WM_USER_SET_TITLE = WM_USER + 0,
 	WM_USER_SHOW,
-	WM_USER_CLOSE_DISPATCHER,
 	WM_USER_CLOSE
 };
 
@@ -81,7 +80,6 @@ public:
 
 	void send_setWindowTitle(const char *title);
 	void send_show();
-	void send_dispatcherClose();
 	void send_close();
 };
 

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -87,6 +87,7 @@ class VSTPlugin {
 
 public:
 	VSTPlugin(obs_source_t *sourceContext);
+	~VSTPlugin();
 	void        loadEffectFromPath(std::string path);
 	void        unloadEffect();
 	void        openEditor();

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -87,7 +87,7 @@ class VSTPlugin {
 public:
 	VSTPlugin(obs_source_t *sourceContext);
 	~VSTPlugin();
-	std::thread deleteWorker;
+	std::thread* deleteWorker;
 
 	void            loadEffectFromPath(std::string path);
 	void            unloadEffect();

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -88,13 +88,14 @@ public:
 	VSTPlugin(obs_source_t *sourceContext);
 	~VSTPlugin();
 	std::thread* deleteWorker;
+	obs_properties_t *sp;
 
 	void            loadEffectFromPath(std::string path);
 	void            unloadEffect();
 	bool            isEditorOpen();
-	void            openEditor();
+	void            openEditor(obs_properties_t *props);
 	void            removeEditor();
-	void            closeEditor(obs_properties_t *props);
+	void            closeEditor();
 	std::string     getChunk();
 	void            setChunk(std::string data);
 	void            setProgram(const int programNumber);

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -35,8 +35,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class EditorWidget;
 
-#define EffectNameLength 64
-
 class VSTPlugin {
 	AEffect *     effect = nullptr;
 	obs_source_t *sourceContext;
@@ -53,7 +51,7 @@ class VSTPlugin {
 
 	std::string sourceName;
 	std::string filterName;
-	char        effectName[EffectNameLength];
+	char        effectName[64];
 	// Remove below... or comment out
 	char vendorString[64];
 

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -27,6 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "aeffectx.h"
 #include "vst-plugin-callbacks.hpp"
 #include "EditorWidget.h"
+#include <thread>
 
 #ifdef __APPLE__
 #include <CoreFoundation/CoreFoundation.h>
@@ -48,12 +49,11 @@ class VSTPlugin {
 
 	bool effectReady = false;
 
-	std::string   sourceName;
-	std::string   filterName;
-	char effectName[64];
+	std::string sourceName;
+	std::string filterName;
+	char        effectName[64];
 	// Remove below... or comment out
 	char vendorString[64];
-
 
 #ifdef __APPLE__
 	CFBundleRef bundle = NULL;
@@ -87,18 +87,21 @@ class VSTPlugin {
 public:
 	VSTPlugin(obs_source_t *sourceContext);
 	~VSTPlugin();
-	void        loadEffectFromPath(std::string path);
-	void        unloadEffect();
-	bool        isEditorOpen();
-	void        openEditor();
-	void        closeEditor();
-	std::string getChunk();
-	void        setChunk(std::string data);
-	void        setProgram(const int programNumber);
-	int         getProgram();
-	void        getSourceNames();
+	std::thread deleteWorker;
+
+	void            loadEffectFromPath(std::string path);
+	void            unloadEffect();
+	bool            isEditorOpen();
+	void            openEditor();
+	void            removeEditor();
+	void            closeEditor();
+	std::string     getChunk();
+	void            setChunk(std::string data);
+	void            setProgram(const int programNumber);
+	int             getProgram();
+	void            getSourceNames();
 	obs_audio_data *process(struct obs_audio_data *audio);
-	bool        openInterfaceWhenActive = false;
+	bool            openInterfaceWhenActive = false;
 };
 
 #endif // OBS_STUDIO_VSTPLUGIN_H

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -88,12 +88,11 @@ public:
 	VSTPlugin(obs_source_t *sourceContext);
 	~VSTPlugin();
 	std::thread* deleteWorker;
-	obs_properties_t *sp;
 
 	void            loadEffectFromPath(std::string path);
 	void            unloadEffect();
 	bool            isEditorOpen();
-	void            openEditor(obs_properties_t *props);
+	void            openEditor();
 	void            removeEditor();
 	void            closeEditor();
 	std::string     getChunk();

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -23,7 +23,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define BLOCK_SIZE 512
 
 #include <string>
-#include <QDirIterator>
 #include <obs-module.h>
 #include "aeffectx.h"
 #include "vst-plugin-callbacks.hpp"
@@ -90,6 +89,7 @@ public:
 	~VSTPlugin();
 	void        loadEffectFromPath(std::string path);
 	void        unloadEffect();
+	bool        isEditorOpen();
 	void        openEditor();
 	void        closeEditor();
 	std::string getChunk();

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -64,6 +64,7 @@ class VSTPlugin {
 #endif
 
 	void unloadLibrary();
+	void waitDeleteWorker();
 
 	static intptr_t
 	hostCallback_static(AEffect *effect, int32_t opcode, int32_t index, intptr_t value, void *ptr, float opt)
@@ -87,7 +88,7 @@ class VSTPlugin {
 public:
 	VSTPlugin(obs_source_t *sourceContext);
 	~VSTPlugin();
-	std::thread* deleteWorker;
+	std::thread* deleteWorker = nullptr;
 
 	void            loadEffectFromPath(std::string path);
 	void            unloadEffect();

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -35,6 +35,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class EditorWidget;
 
+#define EffectNameLength 64
+
 class VSTPlugin {
 	AEffect *     effect = nullptr;
 	obs_source_t *sourceContext;
@@ -51,7 +53,7 @@ class VSTPlugin {
 
 	std::string sourceName;
 	std::string filterName;
-	char        effectName[64];
+	char        effectName[EffectNameLength];
 	// Remove below... or comment out
 	char vendorString[64];
 

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -94,7 +94,7 @@ public:
 	bool            isEditorOpen();
 	void            openEditor();
 	void            removeEditor();
-	void            closeEditor();
+	void            closeEditor(obs_properties_t *props);
 	std::string     getChunk();
 	void            setChunk(std::string data);
 	void            setProgram(const int programNumber);

--- a/obs-vst.cpp
+++ b/obs-vst.cpp
@@ -141,6 +141,7 @@ static void fill_out_plugins(obs_property_t *list)
 		dir_list << qEnvironmentVariable("ProgramFiles") + "/Steinberg/VstPlugins/"
 		         << qEnvironmentVariable("CommonProgramFiles") + "/Steinberg/Shared Components/"
 		         << qEnvironmentVariable("CommonProgramFiles") + "/VST2"
+		         << qEnvironmentVariable("CommonProgramFiles") + "/Steinberg/VST2"
 		         << qEnvironmentVariable("CommonProgramFiles") + "/VSTPlugins/"
 		         << qEnvironmentVariable("ProgramFiles") + "/VSTPlugins/";
 #ifndef _WIN64

--- a/obs-vst.cpp
+++ b/obs-vst.cpp
@@ -138,18 +138,18 @@ static void fill_out_plugins(obs_property_t *list)
 
 	if (!isWow64) {
 #endif
-		dir_list << "C:/Program Files/Steinberg/VstPlugins/"
-		         << "C:/Program Files/Common Files/Steinberg/Shared Components/"
-		         << "C:/Program Files/Common Files/VST2"
-		         << "C:/Program Files/Common Files/VSTPlugins/"
-		         << "C:/Program Files/VSTPlugins/";
+		dir_list << qEnvironmentVariable("ProgramFiles") + "/Steinberg/VstPlugins/"
+		         << qEnvironmentVariable("CommonProgramFiles") + "/Steinberg/Shared Components/"
+		         << qEnvironmentVariable("CommonProgramFiles") + "/VST2"
+		         << qEnvironmentVariable("CommonProgramFiles") + "/VSTPlugins/"
+		         << qEnvironmentVariable("ProgramFiles") + "/VSTPlugins/";
 #ifndef _WIN64
 	} else {
-		dir_list << "C:/Program Files (x86)/Steinberg/VstPlugins/"
-		         << "C:/Program Files (x86)/Common Files/Steinberg/Shared Components/"
-		         << "C:/Program Files (x86)/Common Files/VST2"
-		         << "C:/Program Files (x86)/Common Files/VSTPlugins/"
-		         << "C:/Program Files (x86)/VSTPlugins/";
+		dir_list << qEnvironmentVariable("ProgramFiles(x86)") + "/Steinberg/VstPlugins/"
+		         << qEnvironmentVariable("CommonProgramFiles(x86)") + "/Steinberg/Shared Components/"
+		         << qEnvironmentVariable("CommonProgramFiles(x86)") + "/VST2"
+		         << qEnvironmentVariable("CommonProgramFiles(x86)") + "/VSTPlugins/"
+		         << qEnvironmentVariable("ProgramFiles(x86)") + "/VSTPlugins/";
 	}
 #endif
 #elif __linux__

--- a/obs-vst.cpp
+++ b/obs-vst.cpp
@@ -41,7 +41,7 @@ static bool open_editor_button_clicked(obs_properties_t *props, obs_property_t *
 {
 	VSTPlugin *vstPlugin = (VSTPlugin *)data;
 
-	vstPlugin->openEditor();
+	vstPlugin->openEditor(props);
 
 	obs_property_set_visible(obs_properties_get(props, OPEN_VST_SETTINGS), false);
 	obs_property_set_visible(obs_properties_get(props, CLOSE_VST_SETTINGS), true);
@@ -57,7 +57,7 @@ static bool close_editor_button_clicked(obs_properties_t *props, obs_property_t 
 {
 	VSTPlugin *vstPlugin = (VSTPlugin *)data;
 
-	vstPlugin->closeEditor(props);
+	vstPlugin->closeEditor();
 
 	UNUSED_PARAMETER(property);
 
@@ -73,7 +73,7 @@ static const char *vst_name(void *unused)
 static void vst_destroy(void *data)
 {
 	VSTPlugin *vstPlugin = (VSTPlugin *)data;
-	vstPlugin->closeEditor(NULL);
+	vstPlugin->closeEditor();
 	delete vstPlugin;
 }
 

--- a/obs-vst.cpp
+++ b/obs-vst.cpp
@@ -57,10 +57,7 @@ static bool close_editor_button_clicked(obs_properties_t *props, obs_property_t 
 {
 	VSTPlugin *vstPlugin = (VSTPlugin *)data;
 
-	vstPlugin->closeEditor();
-
-	obs_property_set_visible(obs_properties_get(props, OPEN_VST_SETTINGS), true);
-	obs_property_set_visible(obs_properties_get(props, CLOSE_VST_SETTINGS), false);
+	vstPlugin->closeEditor(props);
 
 	UNUSED_PARAMETER(property);
 
@@ -76,7 +73,7 @@ static const char *vst_name(void *unused)
 static void vst_destroy(void *data)
 {
 	VSTPlugin *vstPlugin = (VSTPlugin *)data;
-	vstPlugin->closeEditor();
+	vstPlugin->closeEditor(NULL);
 	delete vstPlugin;
 }
 

--- a/obs-vst.cpp
+++ b/obs-vst.cpp
@@ -41,7 +41,7 @@ static bool open_editor_button_clicked(obs_properties_t *props, obs_property_t *
 {
 	VSTPlugin *vstPlugin = (VSTPlugin *)data;
 
-	vstPlugin->openEditor(props);
+	vstPlugin->openEditor();
 
 	obs_property_set_visible(obs_properties_get(props, OPEN_VST_SETTINGS), false);
 	obs_property_set_visible(obs_properties_get(props, CLOSE_VST_SETTINGS), true);
@@ -58,6 +58,9 @@ static bool close_editor_button_clicked(obs_properties_t *props, obs_property_t 
 	VSTPlugin *vstPlugin = (VSTPlugin *)data;
 
 	vstPlugin->closeEditor();
+
+	obs_property_set_visible(obs_properties_get(props, OPEN_VST_SETTINGS), true);
+	obs_property_set_visible(obs_properties_get(props, CLOSE_VST_SETTINGS), false);
 
 	UNUSED_PARAMETER(property);
 

--- a/obs-vst.cpp
+++ b/obs-vst.cpp
@@ -16,6 +16,13 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 *****************************************************************************/
 
+#include <string>
+#include <vector>
+#include <algorithm>
+
+#include <util/platform.h>
+#include <util/dstr.h>
+
 #include "headers/VSTPlugin.h"
 
 #define OPEN_VST_SETTINGS "open_vst_settings"
@@ -122,124 +129,138 @@ static struct obs_audio_data *vst_filter_audio(void *data, struct obs_audio_data
 	return audio;
 }
 
-static void fill_out_plugins(obs_property_t *list)
+bool valid_extension(const char *filepath) 
 {
-	QStringList dir_list;
+	const char *ext = os_get_path_extension(filepath);
+	int filters_size = 1;
 
 #ifdef __APPLE__
-	dir_list << "/Library/Audio/Plug-Ins/VST/"
-	         << "~/Library/Audio/Plug-ins/VST/";
+	const char *filters[] = { ".vst" };
 #elif WIN32
-#ifndef _WIN64
-	HANDLE hProcess = GetCurrentProcess();
-
-	BOOL isWow64;
-	IsWow64Process(hProcess, &isWow64);
-
-	if (!isWow64) {
-#endif
-		dir_list << qEnvironmentVariable("ProgramFiles") + "/Steinberg/VstPlugins/"
-		         << qEnvironmentVariable("CommonProgramFiles") + "/Steinberg/Shared Components/"
-		         << qEnvironmentVariable("CommonProgramFiles") + "/VST2"
-		         << qEnvironmentVariable("CommonProgramFiles") + "/Steinberg/VST2"
-		         << qEnvironmentVariable("CommonProgramFiles") + "/VSTPlugins/"
-		         << qEnvironmentVariable("ProgramFiles") + "/VSTPlugins/";
-#ifndef _WIN64
-	} else {
-		dir_list << qEnvironmentVariable("ProgramFiles(x86)") + "/Steinberg/VstPlugins/"
-		         << qEnvironmentVariable("CommonProgramFiles(x86)") + "/Steinberg/Shared Components/"
-		         << qEnvironmentVariable("CommonProgramFiles(x86)") + "/VST2"
-		         << qEnvironmentVariable("CommonProgramFiles(x86)") + "/VSTPlugins/"
-		         << qEnvironmentVariable("ProgramFiles(x86)") + "/VSTPlugins/";
-	}
-#endif
+	const char *filters[] = { ".dll" };
 #elif __linux__
-	// If the user has set the VST_PATH environmental
-	// variable, then use it. Else default to a list
-	// of common locations.
-	char *vstPathEnv;
-	vstPathEnv = getenv("VST_PATH");
-	if (vstPathEnv != nullptr) {
-		dir_list << vstPathEnv;
-	} else {
-		// Choose the most common locations
-		dir_list << "/usr/lib/vst/"
-		         << "/usr/lib/lxvst/"
-		         << "/usr/lib/linux_vst/"
-		         << "/usr/lib64/vst/"
-		         << "/usr/lib64/lxvst/"
-		         << "/usr/lib64/linux_vst/"
-		         << "/usr/local/lib/vst/"
-		         << "/usr/local/lib/lxvst/"
-		         << "/usr/local/lib/linux_vst/"
-		         << "/usr/local/lib64/vst/"
-		         << "/usr/local/lib64/lxvst/"
-		         << "/usr/local/lib64/linux_vst/"
-		         << "~/.vst/"
-		         << "~/.lxvst/";
-	}
+	const char *filters[] = { ".so", ".o" };
+	++filters_size;
 #endif
 
-	QStringList filters;
-
-#ifdef __APPLE__
-	filters << "*.vst";
-#elif WIN32
-	filters << "*.dll";
-#elif __linux__
-	filters << "*.so"
-	        << "*.o";
-#endif
-
-	QStringList vst_list;
-
-	// Read all plugins into a list...
-	for (int a = 0; a < dir_list.size(); ++a) {
-		QDir search_dir(dir_list[a]);
-		search_dir.setNameFilters(filters);
-		QDirIterator it(search_dir, QDirIterator::Subdirectories);
-		while (it.hasNext()) {
-			QString path = it.next();
-			QString name = it.fileName();
-
-#ifdef __APPLE__
-			name.remove(QRegExp("(\\.vst)"));
-#elif WIN32
-			name.remove(QRegExp("(\\.dll)"));
-#elif __linux__
-			name.remove(QRegExp("(\\.so|\\.o)"));
-#endif
-
-			name.append("=").append(path);
-			vst_list << name;
+	for (int i = 0; i < filters_size; ++i) {
+			if (astrcmpi(filters[i], ext) == 0) {
+			return true;
 		}
 	}
 
-	// Now sort list alphabetically (still case-sensitive though).
-	std::stable_sort(vst_list.begin(), vst_list.end(), std::less<QString>());
+	return false;
+}
 
-	// Now add said list to the plug-in list of OBS
+std::vector<std::string> win32_build_dir_list()
+{
+	const char *program_files_path = getenv("ProgramFiles");
+
+	const char* dir_list[] = {
+		"/Steinberg/VstPlugins/",
+		"/Common Files/Steinberg/Shared Components/",
+		"/Common Files/VST2/",
+		"/Common Files/VSTPlugins/",
+		"/VSTPlugins/"
+	};
+
+	const int dir_list_size = 
+		sizeof(dir_list) / sizeof(dir_list[0]);
+
+	std::vector<std::string> result(dir_list_size, program_files_path);
+	
+	for (int i = 0; i < result.size(); ++i) {
+		result[i].append(dir_list[i]);
+	}
+
+	return result;
+}
+
+static void fill_out_plugins(obs_property_t *list)
+{
+#ifdef __APPLE__
+	std::vector<std::string> dir_list({
+		"/Library/Audio/Plug-Ins/VST/",
+		"~/Library/Audio/Plug-ins/VST/"
+	});
+
+#elif WIN32
+	std::vector<std::string> dir_list = win32_build_dir_list();
+
+#elif __linux__
+	char *vstPathEnv = getenv("VST_PATH");
+	if (vstPathEnv != nullptr) {
+		std::string dir_list[] = { vstPathEnv };
+	} else {
+		/* FIXME: Platform dependent areas.
+		   Should use environment variables */
+		std::vector<std::string> dir_list({
+			"/usr/lib/vst/",
+			"/usr/lib/lxvst/",
+			"/usr/lib/linux_vst/",
+			"/usr/lib64/vst/",
+			"/usr/lib64/lxvst/",
+			"/usr/lib64/linux_vst/",
+			"/usr/local/lib/vst/",
+			"/usr/local/lib/lxvst/",
+			"/usr/local/lib/linux_vst/",
+			"/usr/local/lib64/vst/",
+			"/usr/local/lib64/lxvst/",
+			"/usr/local/lib64/linux_vst/",
+			"~/.vst/",
+			"~/.lxvst/"
+		});
+	}
+#endif
+
+	typedef std::pair<std::string, std::string> vst_data;
+	std::vector<vst_data> vst_list;
+
+	for (int i = 0; i < dir_list.size(); ++i) {
+		os_dir_t *dir = os_opendir(dir_list[i].c_str());
+		os_dirent *ent = os_readdir(dir);
+
+		while (ent != NULL) {
+			/* If valid file format */
+			if (valid_extension(ent->d_name)) {
+				std::string path(dir_list[i]);
+				path.append(ent->d_name);
+				vst_list.push_back({ ent->d_name, path });
+			}
+
+			ent = os_readdir(dir);
+		}
+
+		os_closedir(dir);
+	}
+
 	obs_property_list_add_string(list, "{Please select a plug-in}", nullptr);
-	for (int b = 0; b < vst_list.size(); ++b) {
-		QString vst_sorted = vst_list[b];
-		obs_property_list_add_string(list,
-		                             vst_sorted.left(vst_sorted.indexOf('=')).toStdString().c_str(),
-		                             vst_sorted.mid(vst_sorted.indexOf('=') + 1).toStdString().c_str());
+	for (int i = 0; i < vst_list.size(); ++i) {
+		obs_property_list_add_string(list, vst_list[i].first.c_str(), vst_list[i].second.c_str());
 	}
 }
 
 static obs_properties_t *vst_properties(void *data)
 {
+	VSTPlugin *vstPlugin = (VSTPlugin *)data;
+
 	obs_properties_t *props = obs_properties_create();
 	obs_property_t *  list  = obs_properties_add_list(
 	        props, "plugin_path", PLUG_IN_NAME, OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_STRING);
 
 	fill_out_plugins(list);
 
-	obs_properties_add_button(props, OPEN_VST_SETTINGS, OPEN_VST_TEXT, open_editor_button_clicked);
+	obs_property_t *open_button = 
+		obs_properties_add_button(props, OPEN_VST_SETTINGS, OPEN_VST_TEXT, open_editor_button_clicked);
 
-	obs_properties_add_button(props, CLOSE_VST_SETTINGS, CLOSE_VST_TEXT, close_editor_button_clicked);
-	obs_property_set_visible(obs_properties_get(props, CLOSE_VST_SETTINGS), false);
+	obs_property_t *close_button = 
+		obs_properties_add_button(props, CLOSE_VST_SETTINGS, CLOSE_VST_TEXT, close_editor_button_clicked);
+
+	if (vstPlugin->isEditorOpen()) {
+		obs_property_set_visible(open_button, false);
+	} else {
+		obs_property_set_visible(close_button, false);
+	}
 
 	obs_properties_add_bool(props, OPEN_WHEN_ACTIVE_VST_SETTINGS, OPEN_WHEN_ACTIVE_VST_TEXT);
 

--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -19,21 +19,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 void EditorWidget::buildEffectContainer(AEffect *effect)
 {
-	WNDCLASSEX wcex{sizeof(wcex)};
+	WNDCLASSEXW wcex{sizeof(wcex)};
 
-	wcex.lpfnWndProc   = DefWindowProc;
-	wcex.hInstance     = GetModuleHandle(0);
+	wcex.lpfnWndProc   = DefWindowProcW;
+	wcex.hInstance     = GetModuleHandleW(nullptr);
 	wcex.lpszClassName = L"Minimal VST host - Guest VST Window Frame";
-	RegisterClassEx(&wcex);
+	RegisterClassExW(&wcex);
 
 	const auto style = WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPEDWINDOW;
-	HWND hwnd = CreateWindow(wcex.lpszClassName, TEXT(""), style, 0, 0, 0, 0, nullptr, nullptr, nullptr, nullptr);
+	windowHandle =
+	        CreateWindowW(wcex.lpszClassName, TEXT(""), style, 0, 0, 0, 0, nullptr, nullptr, nullptr, nullptr);
 
-	QWidget *widget = QWidget::createWindowContainer(QWindow::fromWinId((WId)hwnd), this);
+	// set pointer to vst effect for window long
+	LONG_PTR wndPtr = (LONG_PTR)effect;
+	SetWindowLongPtr(windowHandle, -21 /*GWLP_USERDATA*/, wndPtr);
+
+	QWidget *widget = QWidget::createWindowContainer(QWindow::fromWinId((WId)windowHandle), this);
 	widget->move(0, 0);
 	widget->resize(300, 300);
 
-	effect->dispatcher(effect, effEditOpen, 0, 0, hwnd, 0);
+	effect->dispatcher(effect, effEditOpen, 0, 0, windowHandle, 0);
 
 	VstRect *vstRect = nullptr;
 	effect->dispatcher(effect, effEditGetRect, 0, 0, &vstRect, 0);
@@ -44,7 +49,43 @@ void EditorWidget::buildEffectContainer(AEffect *effect)
 
 void EditorWidget::handleResizeRequest(int, int)
 {
-	// We don't have to do anything here as far as I can tell.
-	// The widget will resize the HWIND itself and then this
-	// widget will automatically size depending on that.
+	// Some plugins can't resize automatically (like SPAN by Voxengo),
+	// so we must resize window manually
+
+	// get pointer to vst effect from window long
+	LONG_PTR    wndPtr   = (LONG_PTR)GetWindowLongPtrW(windowHandle, -21 /*GWLP_USERDATA*/);
+	AEffect *   effect   = (AEffect *)(wndPtr);
+	VstRect *   rec      = nullptr;
+	static RECT PluginRc = {0};
+	RECT        winRect  = {0};
+
+	GetWindowRect(windowHandle, &winRect);
+	if (effect) {
+		effect->dispatcher(effect, effEditGetRect, 1, 0, &rec, 0);
+	}
+
+	// compare window rect with VST Rect
+	if (rec) {
+		if (PluginRc.bottom != rec->bottom || PluginRc.left != rec->left || PluginRc.right != rec->right ||
+		    PluginRc.top != rec->top) {
+			PluginRc.bottom = rec->bottom;
+			PluginRc.left   = rec->left;
+			PluginRc.right  = rec->right;
+			PluginRc.top    = rec->top;
+
+			// set rect to our window
+			AdjustWindowRectEx(&PluginRc,
+							   WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPEDWINDOW,
+			                   FALSE,
+			                   0);
+
+			// move window to apply pos
+			MoveWindow(windowHandle,
+			           winRect.left,
+			           winRect.top,
+			           PluginRc.right - PluginRc.left,
+			           PluginRc.bottom - PluginRc.top,
+			           TRUE);
+		}
+	}
 }

--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -28,6 +28,17 @@ LRESULT WINAPI EffectWindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 	switch (uMsg) {
 	case WM_CLOSE:
 		plugin->closeEditor();
+		obs_properties_t *props = obs_properties_create();
+		obs_property_t *  list  = obs_properties_add_list(props,
+                                                               "plugin_path",
+                                                               obs_module_text("VstPlugin"),
+                                                               OBS_COMBO_TYPE_LIST,
+                                                               OBS_COMBO_FORMAT_STRING);
+
+		if (props) {
+			obs_property_set_visible(obs_properties_get(props, "open_vst_settings"), true);
+			obs_property_set_visible(obs_properties_get(props, "close_vst_settings"), false);
+		}
 	}
 
 	return DefWindowProc(hWnd, uMsg, wParam, lParam);

--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -129,6 +129,12 @@ void EditorWidget::buildEffectContainer_worker()
 void EditorWidget::setWindowTitle(const char *title)
 {
 	TCHAR wstrTitle[256];
+
+	// Check for invalid strings
+	if (!title || MultiByteToWideChar(CP_UTF8, 0, title, -1, &wstrTitle[0], 0) > 255) {
+		return;
+	}
+
 	MultiByteToWideChar(CP_UTF8, 0, title, -1, &wstrTitle[0], 256);
 	SetWindowText(m_hwnd, &wstrTitle[0]);
 }

--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -27,7 +27,7 @@ LRESULT WINAPI EffectWindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 
 	switch (uMsg) {
 	case WM_CLOSE:
-		plugin->closeEditor(NULL);
+		plugin->closeEditor();
 	}
 
 	return DefWindowProc(hWnd, uMsg, wParam, lParam);

--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -113,6 +113,8 @@ void EditorWidget::buildEffectContainer_worker()
 				setWindowTitle(title);
 			} else if (msg.message == WM_USER_SHOW) {
 				show();
+			} else if (msg.message == WM_USER_CLOSE_DISPATCHER) {
+				dispatcherClose();
 			} else if (msg.message == WM_USER_CLOSE) {
 				close();
 				shutdown = true;
@@ -161,4 +163,16 @@ void EditorWidget::send_show()
 {
 	PostThreadMessage(GetThreadId(windowWorker.native_handle()),
 		WM_USER_SHOW, 0, 0);
+}
+
+void EditorWidget::dispatcherClose()
+{
+	if (m_effect) {
+		m_effect->dispatcher(m_effect, effEditClose, 0, 0, nullptr, 0);
+	}
+}
+
+void EditorWidget::send_dispatcherClose()
+{
+	PostThreadMessage(GetThreadId(windowWorker.native_handle()), WM_USER_CLOSE_DISPATCHER, 0, 0);
 }

--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -114,9 +114,9 @@ void EditorWidget::buildEffectContainer_worker()
 			} else if (msg.message == WM_USER_SHOW) {
 				show();
 			} else if (msg.message == WM_USER_CLOSE_DISPATCHER) {
-				dispatcherClose();
 			} else if (msg.message == WM_USER_CLOSE) {
 				close();
+				dispatcherClose();
 				shutdown = true;
 			}
 			TranslateMessage(&msg);

--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -113,7 +113,6 @@ void EditorWidget::buildEffectContainer_worker()
 				setWindowTitle(title);
 			} else if (msg.message == WM_USER_SHOW) {
 				show();
-			} else if (msg.message == WM_USER_CLOSE_DISPATCHER) {
 			} else if (msg.message == WM_USER_CLOSE) {
 				close();
 				dispatcherClose();
@@ -170,9 +169,4 @@ void EditorWidget::dispatcherClose()
 	if (m_effect) {
 		m_effect->dispatcher(m_effect, effEditClose, 0, 0, nullptr, 0);
 	}
-}
-
-void EditorWidget::send_dispatcherClose()
-{
-	PostThreadMessage(GetThreadId(windowWorker.native_handle()), WM_USER_CLOSE_DISPATCHER, 0, 0);
 }

--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -28,17 +28,6 @@ LRESULT WINAPI EffectWindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 	switch (uMsg) {
 	case WM_CLOSE:
 		plugin->closeEditor();
-		obs_properties_t *props = obs_properties_create();
-		obs_property_t *  list  = obs_properties_add_list(props,
-                                                               "plugin_path",
-                                                               obs_module_text("VstPlugin"),
-                                                               OBS_COMBO_TYPE_LIST,
-                                                               OBS_COMBO_FORMAT_STRING);
-
-		if (props) {
-			obs_property_set_visible(obs_properties_get(props, "open_vst_settings"), true);
-			obs_property_set_visible(obs_properties_get(props, "close_vst_settings"), false);
-		}
 	}
 
 	return DefWindowProc(hWnd, uMsg, wParam, lParam);

--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -27,7 +27,7 @@ LRESULT WINAPI EffectWindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 
 	switch (uMsg) {
 	case WM_CLOSE:
-		plugin->closeEditor();
+		plugin->closeEditor(NULL);
 	}
 
 	return DefWindowProc(hWnd, uMsg, wParam, lParam);

--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -129,12 +129,6 @@ void EditorWidget::buildEffectContainer_worker()
 void EditorWidget::setWindowTitle(const char *title)
 {
 	TCHAR wstrTitle[256];
-
-	// Check for invalid strings
-	if (!title || MultiByteToWideChar(CP_UTF8, 0, title, -1, &wstrTitle[0], 0) > 255) {
-		return;
-	}
-
 	MultiByteToWideChar(CP_UTF8, 0, title, -1, &wstrTitle[0], 256);
 	SetWindowText(m_hwnd, &wstrTitle[0]);
 }

--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -15,29 +15,84 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 *****************************************************************************/
 
+#include <Dwmapi.h>
 #include "../headers/EditorWidget.h"
+
+LRESULT WINAPI EffectWindowProc(
+		HWND   hWnd,
+		UINT   uMsg,
+		WPARAM wParam,
+		LPARAM lParam)
+{
+	VSTPlugin *plugin = (VSTPlugin*)GetWindowLongPtr(hWnd, GWLP_USERDATA);
+
+	switch (uMsg) {
+	case WM_CLOSE: 
+		plugin->closeEditor();
+	}
+
+	return DefWindowProc(hWnd, uMsg, wParam, lParam);
+}
 
 void EditorWidget::buildEffectContainer(AEffect *effect)
 {
 	WNDCLASSEXW wcex{sizeof(wcex)};
 
-	wcex.lpfnWndProc   = DefWindowProcW;
-	wcex.hInstance     = GetModuleHandleW(nullptr);
+	wcex.lpfnWndProc   = EffectWindowProc;
+	wcex.hInstance     = GetModuleHandle(0);
 	wcex.lpszClassName = L"Minimal VST host - Guest VST Window Frame";
 	RegisterClassExW(&wcex);
 
-	const auto style = WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPEDWINDOW;
-	m_hwnd = CreateWindow(wcex.lpszClassName, TEXT(""), style, 0, 0, 0, 0, nullptr, nullptr, nullptr, nullptr);
-
-	MoveWindow(m_hwnd, 0, 0, 300, 300, false);
-
-	effect->dispatcher(effect, effEditOpen, 0, 0, m_hwnd, 0);
+	LONG style = 
+		WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_DLGFRAME 
+		| WS_POPUP | WS_SYSMENU | WS_CAPTION | WS_MINIMIZEBOX;
+		
+	LONG exStyle = WS_EX_DLGMODALFRAME;
 
 	VstRect *vstRect = nullptr;
 	effect->dispatcher(effect, effEditGetRect, 0, 0, &vstRect, 0);
+
+	RECT rect = { 0 };
+	
 	if (vstRect) {
-		MoveWindow(m_hwnd, vstRect->left, vstRect->top, vstRect->right, vstRect->bottom, false);
+		rect.left = vstRect->left;
+		rect.right = vstRect->right;
+		rect.top = vstRect->top;
+		rect.bottom = vstRect->bottom;
+
+		AdjustWindowRectEx(&rect, style, false, exStyle);
 	}
+
+	m_hwnd = 
+	CreateWindowEx(exStyle, wcex.lpszClassName, TEXT(""), style, 
+		rect.left, rect.top, rect.right, rect.bottom, 
+		nullptr, nullptr, nullptr, nullptr);
+
+	SetWindowLongPtr(m_hwnd, GWLP_USERDATA, (LONG_PTR)plugin);
+
+	/* Despite the use of AdjustWindowRectEx here, the docs lie to us 
+	   when they say it will give us the smallest size to accomodate the
+	   client area wanted. Since Vista came out, we now have to take into
+	   account hidden borders introduced by DWM. This can only be done 
+	   *after* we've created the window as well. */
+	RECT frame;
+	DwmGetWindowAttribute(m_hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, &frame, sizeof(RECT));
+	
+	RECT border;
+	border.left = frame.left - rect.left;
+	border.top = frame.top - rect.top;
+	border.right = rect.right - frame.right;
+	border.bottom = rect.bottom - frame.bottom;
+	
+	rect.left -= border.left;
+	rect.top -= border.top;
+	rect.right += border.left + border.right;
+	rect.bottom += border.top + border.bottom;
+
+	SetWindowPos(m_hwnd, 0, rect.left, rect.top, rect.right, rect.bottom, 0);
+	SetWindowPos(m_hwnd, 0, 0, 0, 0, 0, SWP_NOSIZE);
+
+	effect->dispatcher(effect, effEditOpen, 0, 0, m_hwnd, 0);
 }
 
 void EditorWidget::setWindowTitle(const char *title)
@@ -60,43 +115,4 @@ void EditorWidget::show()
 
 void EditorWidget::handleResizeRequest(int width, int height)
 {
-	// Some plugins can't resize automatically (like SPAN by Voxengo),
-	// so we must resize window manually
-
-	// get pointer to vst effect from window long
-	LONG_PTR    wndPtr   = (LONG_PTR)GetWindowLongPtrW(m_hwnd, -21 /*GWLP_USERDATA*/);
-	AEffect *   effect   = (AEffect *)(wndPtr);
-	VstRect *   rec      = nullptr;
-	static RECT PluginRc = {0};
-	RECT        winRect  = {0};
-
-	GetWindowRect(m_hwnd, &winRect);
-	if (effect) {
-		effect->dispatcher(effect, effEditGetRect, 1, 0, &rec, 0);
-	}
-
-	// compare window rect with VST Rect
-	if (rec) {
-		if (PluginRc.bottom != rec->bottom || PluginRc.left != rec->left || PluginRc.right != rec->right ||
-		    PluginRc.top != rec->top) {
-			PluginRc.bottom = rec->bottom;
-			PluginRc.left   = rec->left;
-			PluginRc.right  = rec->right;
-			PluginRc.top    = rec->top;
-
-			// set rect to our window
-			AdjustWindowRectEx(&PluginRc,
-							   WS_CAPTION | WS_THICKFRAME | WS_OVERLAPPEDWINDOW,
-			                   FALSE,
-			                   0);
-
-			// move window to apply pos
-			MoveWindow(m_hwnd,
-			           winRect.left,
-			           winRect.top,
-			           PluginRc.right - PluginRc.left,
-			           PluginRc.bottom - PluginRc.top,
-			           TRUE);
-		}
-	}
 }

--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -20,13 +20,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 LRESULT WINAPI EffectWindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+	if (!hWnd)
+		return NULL;
+
 	VSTPlugin *plugin = (VSTPlugin *)GetWindowLongPtr(hWnd, GWLP_USERDATA);
 
 	switch (uMsg) {
 	case WM_CLOSE:
 		plugin->closeEditor();
-
-		DefWindowProc(hWnd, uMsg, wParam, lParam);
 	}
 
 	return DefWindowProc(hWnd, uMsg, wParam, lParam);
@@ -119,6 +120,7 @@ void EditorWidget::buildEffectContainer_worker()
 			} else if (msg.message == WM_USER_CLOSE) {
 				close();
 				shutdown = true;
+				blog(LOG_DEBUG, "shutdown true");
 			}
 			TranslateMessage(&msg);
 			DispatchMessage(&msg);

--- a/win/VSTPlugin-win.cpp
+++ b/win/VSTPlugin-win.cpp
@@ -42,7 +42,7 @@ AEffect *VSTPlugin::loadEffect()
 			blog(LOG_WARNING,
 			     "Failed trying to load VST from '%s'"
 			     ", error %d\n",
-			     pluginPath,
+			     pluginPath.c_str(),
 			     GetLastError());
 		}
 		return nullptr;


### PR DESCRIPTION
For some reason some vst plugin were trying to call methods on our main window with invalid arguments, causing random crashes, this PR will offset the messages indexes that we use to communicate with our window so if a plugin tries something it won't be successful 