### PR TITLE
send effStopProcess at vst unload

### DIFF
--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -171,6 +171,7 @@ void VSTPlugin::unloadEffect()
 	effectReady = false;
 
 	if (effect) {
+		effect->dispatcher(effect, effStopProcess, 0, 0, nullptr, 0);
 		effect->dispatcher(effect, effMainsChanged, 0, 0, nullptr, 0);
 		effect->dispatcher(effect, effClose, 0, 0, nullptr, 0.0f);
 	}


### PR DESCRIPTION
on some vst plugins effClose can stuck if called without effStopProcess.  