### PR TITLE
Vst closed window

### DIFF
--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -255,7 +255,6 @@ void VSTPlugin::closeEditor(bool waitDeleteWorkerOnShutdown)
 			"VST Plug-in: closeEditor, editor is NOT open"
 		);
 	}
-	unloadEffect();
 }
 
 intptr_t VSTPlugin::hostCallback(AEffect *effect, int32_t opcode, int32_t index, intptr_t value, void *ptr, float opt)

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -384,6 +384,7 @@ void VSTPlugin::setChunk(ChunkType type, std::string & data)
 
 	if ( this->chunkDataPath != this->pluginPath) {
 		blog(LOG_WARNING, "VST Plug-in: setChunk Invalid chunk settings for plugin. Path missmatch.");
+		data = "";
 		return;
 	}
 

--- a/VSTPlugin.cpp
+++ b/VSTPlugin.cpp
@@ -203,6 +203,9 @@ bool VSTPlugin::isEditorOpen()
 
 bool VSTPlugin::hasWindowOpen()
 {
+	if (editorWidget->hiddenWindow) {
+		return false;
+	}
 	return (editorWidget && editorWidget->m_hwnd != 0);
 }
 
@@ -214,8 +217,17 @@ void VSTPlugin::openEditor()
 		editorWidget = new EditorWidget(this);
 		editorWidget->buildEffectContainer();
 	}
+	blog(LOG_WARNING, "VST Plug-in: openEditor send_show");
 	
 	editorWidget->send_show();
+}
+
+void VSTPlugin::hideEditor()
+{
+	is_open = false;
+	if (editorWidget && editorWidget->m_hwnd != 0) {
+		editorWidget->send_hide();
+	}
 }
 
 void VSTPlugin::removeEditor() {

--- a/headers/EditorWidget.h
+++ b/headers/EditorWidget.h
@@ -51,7 +51,8 @@ enum WM_USER_MSG {
 	WM_USER_SHOW,
 	WM_USER_CLOSE,
 	WM_USER_LOAD_DLL,
-	WM_USER_SETCHUNK
+	WM_USER_SETCHUNK,
+	WM_USER_HIDE
 };
 
 #endif
@@ -83,7 +84,7 @@ class EditorWidget {
 
 public:
 	std::thread windowWorker;
-
+	bool        hiddenWindow;
 	EditorWidget(VSTPlugin *plugin);
 	virtual ~EditorWidget();
 	void setWindowTitle(const char *title);
@@ -97,6 +98,7 @@ public:
 	void send_loadEffectFromPath(std::string path);
 	void send_setWindowTitle(const char *title);
 	void send_show();
+	void send_hide();
 	void send_close();
 };
 

--- a/headers/VSTPlugin.h
+++ b/headers/VSTPlugin.h
@@ -107,6 +107,7 @@ public:
 	void            openEditor();
 	void            removeEditor();
 	void            closeEditor(bool waitDeleteWorkerOnShutdown = false);
+	void            hideEditor();
 	std::string     getChunk();
 	void            send_setChunk(std::string data);
 	void            setChunk(std::string data);

--- a/obs-vst.cpp
+++ b/obs-vst.cpp
@@ -63,7 +63,7 @@ static bool close_editor_button_clicked(obs_properties_t *props, obs_property_t 
 	VSTPlugin *vstPlugin = (VSTPlugin *)data;
 	blog(LOG_WARNING, "Close editor btn clicked");
 
-	vstPlugin->closeEditor();
+	vstPlugin->hideEditor();
 
 	UNUSED_PARAMETER(property);
 
@@ -104,10 +104,16 @@ static void vst_update(void *data, obs_data_t *settings)
 	}
 
 	if (load_vst) {
+		// unload previous effect only when changing
+		if (vstPlugin->getPluginPath().compare(std::string(path)) != 0) {
+			vstPlugin->closeEditor();
+			vstPlugin->unloadEffect();
+		}
 		if (!vstPlugin->editorWidget) {
 			vstPlugin->editorWidget = new EditorWidget(vstPlugin);
 			vstPlugin->editorWidget->buildEffectContainer();
 		}
+		
 		vstPlugin->send_loadEffectFromPath(std::string(path));
 
 		// Load chunk only when creating the filter

--- a/win/EditorWidget-win.cpp
+++ b/win/EditorWidget-win.cpp
@@ -169,6 +169,9 @@ void EditorWidget::buildEffectContainer_worker()
 			} else if (msg.message == WM_USER_HIDE) {
 				hiddenWindow = true;
 				ShowWindow(m_hwnd, SW_HIDE);
+				plugin->chunkDataBank = plugin->getChunk(ChunkType::Bank, true);
+				plugin->chunkDataProgram = plugin->getChunk(ChunkType::Program, true);
+				plugin->chunkDataParameter = plugin->getChunk(ChunkType::Parameter, true);
 			}
 			else if (msg.message == WM_USER_CLOSE) {
 				if (shutdown) {


### PR DESCRIPTION
 - When pressing close button , VST is hidden (optimize)
 - When changing VST, VST processing thread is destroyed
 - This fixed issues with the initial implementation which only removed the `unloadEffect`
 - Fixes also VST effect when the window is not visible