### PR TITLE
Fix racing bug for EditorWidget thread missing messages

### DIFF
--- a/headers/EditorWidget.h
+++ b/headers/EditorWidget.h
@@ -77,7 +77,8 @@ class EditorWidget {
 	bool        needs_to_show_window;
 	HWND        m_hwnd;
 	std::mutex  m_threadCloseMtx;
-	std::atomic<bool> m_threadActive{false};
+	std::atomic<bool> m_threadCreated{false};
+	std::atomic<bool> m_threadReady{false};
 
 	void        createWindow();
 #ifdef __linux__


### PR DESCRIPTION
Although the thread is immediately "created", it's not ready for receiving messages until windows completes the initialization and starts it